### PR TITLE
Add-radial-gradient-support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,9 +17,9 @@ export default function () {
   })
 
   on<ReqInsertCSSHandler>("REQ_INSERT_CSS", function (css: string) {
-    // createRectangleWithFill(css)
+    createRectangleWithFill(css)
     // testGradientAngles()
-    testRadialGradients()
+    // testRadialGradients()
   })
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,8 +17,9 @@ export default function () {
   })
 
   on<ReqInsertCSSHandler>("REQ_INSERT_CSS", function (css: string) {
-    createRectangleWithFill(css)
+    // createRectangleWithFill(css)
     // testGradientAngles()
+    testRadialGradients()
   })
 }
 
@@ -70,4 +71,18 @@ function testGradientAngles() {
   createRectangleWithFill(
     "linear-gradient(315deg, rgb(236, 72, 153), rgb(239, 68, 68), rgb(234, 179, 8))"
   )
+}
+
+function testRadialGradients() {
+  // replace center, center with just center
+  createRectangleWithFill(
+    "radial-gradient(at center, rgb(253, 230, 138), rgb(124, 58, 237), rgb(12, 74, 110))"
+  )
+  // createRectangleWithFill(
+  //   "radial-gradient(at 50% 50%, rgb(253, 230, 138), rgb(124, 58, 237), rgb(12, 74, 110))"
+  // )
+  createRectangleWithFill(
+    "radial-gradient(rgb(253, 230, 138), rgb(124, 58, 237), rgb(12, 74, 110))"
+  )
+  // 'radial-gradient(at center top, rgb(253, 230, 138), rgb(124, 58, 237), rgb(12, 74, 110))'
 }

--- a/src/shared/color.ts
+++ b/src/shared/color.ts
@@ -147,11 +147,14 @@ function calculateRotationAngle(parsedGradient: GradientNode): number {
         additionalRotation
       )
       return degreesToRadians(additionalRotation)
-    } else if ((parsedGradient.type as any) === "radial-gradient") {
-      additionalRotation = -90
     } else if (parsedGradient.type === "linear-gradient" && !parsedGradient.orientation) {
       additionalRotation = 0 // default to bottom
     }
+  } else if (parsedGradient.type === "radial-gradient") {
+    // if size is 'furthers-corner' which is the default, then the rotation is 45 to reach corner
+    // any corner will do, but we will use the bottom right corner
+    // since the parser is not smart enough to know that, we just assume that for now
+    additionalRotation = 45
   }
 
   return initialRotation + degreesToRadians(additionalRotation)
@@ -200,7 +203,10 @@ function calculateScale(parsedGradient: GradientNode): [number, number] {
       return [1.0, 1.0] // default to bottom
     }
   } else if (parsedGradient.type === "radial-gradient") {
-    return [1.0, 1.0]
+    // if size is 'furthers-corner' which is the default, then the scale is sqrt(2)
+    // since the parser is not smart enough to know that, we just assume that for now
+    const scale = 1 / Math.sqrt(2)
+    return [scale, scale]
   }
 
   return [1.0, 1.0]
@@ -263,7 +269,7 @@ function calculateTranslationToCenter(parsedGradient: GradientNode): [number, nu
       parsedGradient.colorStops[0].length?.value === "center" ||
       parsedGradient.colorStops[0].length === undefined
     ) {
-      return [-0.5, 0]
+      return [0, 0]
     }
 
     return [0, 0]

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,4 +1,5 @@
 import { Container, Textbox, Text, Button } from "@create-figma-plugin/ui"
+import { parse as parseGradient } from "gradient-parser"
 import { emit } from "@create-figma-plugin/utilities"
 import { h, JSX } from "preact"
 import { useState } from "preact/hooks"
@@ -6,28 +7,66 @@ import { ReqInsertCSSHandler } from "../shared/types"
 
 export function App() {
   const [cssGradient, setCssGradient] = useState<string>("")
+  const [validCss, setValidCss] = useState<boolean>(true)
+
   function handleInput(event: JSX.TargetedEvent<HTMLInputElement>) {
+    setValidCss(true)
     const newValue = event.currentTarget.value
     console.log(newValue)
     setCssGradient(newValue)
   }
 
+  function checkValidCss() {
+    console.log("check valid css")
+    try {
+      const parsedGradient = parseGradient(cssGradient.replace(/;$/, ""))[0]
+      if (parsedGradient) {
+        setValidCss(true)
+        return true
+      } else {
+        setValidCss(false)
+        return false
+      }
+    } catch (e) {
+      setValidCss(false)
+      return false
+    }
+  }
+
   function handleInsert() {
-    emit<ReqInsertCSSHandler>("REQ_INSERT_CSS", cssGradient)
+    if (checkValidCss()) {
+      emit<ReqInsertCSSHandler>("REQ_INSERT_CSS", cssGradient)
+    }
   }
 
   return (
     <Container space='small' style={{ marginTop: 16 }}>
       <Text style={{ marginBottom: 8 }}>CSS Gradient</Text>
       <Textbox
+        style={{ color: validCss ? "initial" : "#F24822" }}
         onInput={handleInput}
         placeholder='linear-gradient(to right, ...)'
         value={cssGradient}
         variant='border'
+        // hack to make the textbox validate without clearing
+        validateOnBlur={() => {
+          checkValidCss()
+          return true
+        }}
       />
-      <Button style={{ marginTop: 8 }} onClick={handleInsert}>
-        Insert
-      </Button>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginTop: 8
+        }}
+      >
+        <Button onClick={handleInsert} disabled={!validCss}>
+          Insert
+        </Button>
+        {!validCss && <Text>Invalid CSS Gradient</Text>}
+      </div>
     </Container>
   )
 }


### PR DESCRIPTION
Partial support, only supports centeral orientation for gradients.

The parser doesn't let us get enough information and doesn't work in certain cases.

I've also added a validation check to see if the parser will allow the css string