### PR TITLE
feat: move to postcss-value-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,23 +4,23 @@
   "dependencies": {
     "@create-figma-plugin/ui": "^2.1.3",
     "@create-figma-plugin/utilities": "^2.1.3",
-    "gradient-parser": "^1.0.2",
-    "hex-rgb": "^5.0.0",
+    "colord": "^2.9.3",
+    "postcss-value-parser": "^4.2.0",
     "preact": "^10",
-    "rgb-hex": "^4.0.0",
     "transformation-matrix": "^2.13.0"
   },
   "devDependencies": {
     "@create-figma-plugin/build": "^2.1.3",
     "@create-figma-plugin/tsconfig": "^2.1.3",
     "@figma/plugin-typings": "1.50.0",
-    "@types/gradient-parser": "^0.1.2",
     "mathjs": "^11.2.1",
-    "typescript": "^4"
+    "typescript": "^4",
+    "vitest": "^0.24.3"
   },
   "scripts": {
     "build": "build-figma-plugin --typecheck --minify",
-    "watch": "build-figma-plugin --typecheck --watch"
+    "watch": "build-figma-plugin --typecheck --watch",
+    "test": "vitest"
   },
   "figma-plugin": {
     "editorType": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@create-figma-plugin/tsconfig": "^2.1.3",
     "@figma/plugin-typings": "1.50.0",
     "mathjs": "^11.2.1",
-    "typescript": "^4",
+    "typescript": "^4.8.4",
     "vitest": "^0.24.3"
   },
   "scripts": {

--- a/src/lib/gradientParser.test.ts
+++ b/src/lib/gradientParser.test.ts
@@ -1,0 +1,173 @@
+import { assert, expect, test } from "vitest"
+import { parseGradient } from "./gradientParser"
+
+test("parseGradient(linear-gradient)", () => {
+  expect(parseGradient("linear-gradient(180deg, red)")).toStrictEqual(
+    parseGradient("linear-gradient(rgb(255, 0, 0))")
+  )
+  expect(parseGradient("linear-gradient(blue 0)")).toStrictEqual(
+    parseGradient("linear-gradient(blue 0px)")
+  )
+  expect(parseGradient("linear-gradient(to left, red, blue)")).toMatchInlineSnapshot(`
+    [
+      {
+        "colorStops": [
+          {
+            "rgba": {
+              "a": 1,
+              "b": 0,
+              "g": 0,
+              "r": 255,
+            },
+            "type": "color-stop",
+          },
+          {
+            "rgba": {
+              "a": 1,
+              "b": 255,
+              "g": 0,
+              "r": 0,
+            },
+            "type": "color-stop",
+          },
+        ],
+        "orientation": {
+          "type": "directional",
+          "value": "left",
+        },
+        "type": "linear-gradient",
+      },
+    ]
+  `)
+  expect(parseGradient("linear-gradient(0.25turn, #fff 10px, 50%, red)")).toMatchInlineSnapshot(`
+    [
+      {
+        "colorStops": [
+          {
+            "position": {
+              "unit": "px",
+              "value": 10,
+            },
+            "rgba": {
+              "a": 1,
+              "b": 255,
+              "g": 255,
+              "r": 255,
+            },
+            "type": "color-stop",
+          },
+          {
+            "hint": {
+              "unit": "%",
+              "value": 50,
+            },
+            "type": "color-hint",
+          },
+          {
+            "rgba": {
+              "a": 1,
+              "b": 0,
+              "g": 0,
+              "r": 255,
+            },
+            "type": "color-stop",
+          },
+        ],
+        "orientation": {
+          "type": "angular",
+          "value": 90,
+        },
+        "type": "linear-gradient",
+      },
+    ]
+  `)
+})
+
+test("parseGradient(radial-gradient)", () => {
+  expect(parseGradient("radial-gradient(5em circle at top left, yellow, blue)"))
+    .toMatchInlineSnapshot(`
+      [
+        {
+          "colorStops": [
+            {
+              "rgba": {
+                "a": 1,
+                "b": 0,
+                "g": 255,
+                "r": 255,
+              },
+              "type": "color-stop",
+            },
+            {
+              "rgba": {
+                "a": 1,
+                "b": 255,
+                "g": 0,
+                "r": 0,
+              },
+              "type": "color-stop",
+            },
+          ],
+          "endingShape": "circle",
+          "position": "top left",
+          "size": "farthest-corner",
+          "type": "radial-gradient",
+        },
+      ]
+    `)
+  expect(
+    [
+      "ellipse farthest-corner",
+      // 'ellipse cover',
+      // 'circle cover',
+      // 'center bottom, ellipse cover',
+      "circle at 87.23px -58.3px",
+      "farthest-side",
+      "farthest-corner",
+      "farthest-corner at 87.23px -58.3px"
+    ].map((declaration) => {
+      const [{ colorStops, ...rest }] = parseGradient(
+        `radial-gradient(${declaration}, red, blue)`
+      )
+      return { DECL: declaration, ...rest }
+    })
+  ).toMatchInlineSnapshot(`
+    [
+      {
+        "DECL": "ellipse farthest-corner",
+        "endingShape": "ellipse",
+        "position": "center",
+        "size": "farthest-corner",
+        "type": "radial-gradient",
+      },
+      {
+        "DECL": "circle at 87.23px -58.3px",
+        "endingShape": "circle",
+        "position": "87.23px -58.3px",
+        "size": "farthest-corner",
+        "type": "radial-gradient",
+      },
+      {
+        "DECL": "farthest-side",
+        "endingShape": "ellipse",
+        "position": "center",
+        "size": "farthest-side",
+        "type": "radial-gradient",
+      },
+      {
+        "DECL": "farthest-corner",
+        "endingShape": "ellipse",
+        "position": "center",
+        "size": "farthest-corner",
+        "type": "radial-gradient",
+      },
+      {
+        "DECL": "farthest-corner at 87.23px -58.3px",
+        "endingShape": "ellipse",
+        "position": "87.23px -58.3px",
+        "size": "farthest-corner",
+        "type": "radial-gradient",
+      },
+    ]
+  `)
+})

--- a/src/lib/gradientParser.test.ts
+++ b/src/lib/gradientParser.test.ts
@@ -126,9 +126,7 @@ test("parseGradient(radial-gradient)", () => {
       "farthest-corner",
       "farthest-corner at 87.23px -58.3px"
     ].map((declaration) => {
-      const [{ colorStops, ...rest }] = parseGradient(
-        `radial-gradient(${declaration}, red, blue)`
-      )
+      const [{ colorStops, ...rest }] = parseGradient(`radial-gradient(${declaration}, red, blue)`)
       return { DECL: declaration, ...rest }
     })
   ).toMatchInlineSnapshot(`
@@ -169,5 +167,117 @@ test("parseGradient(radial-gradient)", () => {
         "type": "radial-gradient",
       },
     ]
+    `)
+})
+
+test("parseGradient(conic-gradient)", () => {
+  expect(parseGradient("conic-gradient(from 3.1416rad at 10% 50%, #e66465, #9198e5)"))
+    .toMatchInlineSnapshot(`
+    [
+      {
+        "angle": 180.0004209182994,
+        "colorStops": [
+          {
+            "rgba": {
+              "a": 1,
+              "b": 101,
+              "g": 100,
+              "r": 230,
+            },
+            "type": "angular-color-stop",
+          },
+          {
+            "rgba": {
+              "a": 1,
+              "b": 229,
+              "g": 152,
+              "r": 145,
+            },
+            "type": "angular-color-stop",
+          },
+        ],
+        "position": "10% 50%",
+        "type": "conic-gradient",
+      },
+    ]
   `)
+  expect(
+    parseGradient(
+      "conic-gradient(red 0deg, orange 90deg, yellow 180deg, green 270deg, blue 360deg)"
+    )
+  ).toMatchInlineSnapshot(`
+      [
+        {
+          "colorStops": [
+            {
+              "angle": {
+                "unit": "deg",
+                "value": 0,
+              },
+              "rgba": {
+                "a": 1,
+                "b": 0,
+                "g": 0,
+                "r": 255,
+              },
+              "type": "angular-color-stop",
+            },
+            {
+              "angle": {
+                "unit": "deg",
+                "value": 90,
+              },
+              "rgba": {
+                "a": 1,
+                "b": 0,
+                "g": 165,
+                "r": 255,
+              },
+              "type": "angular-color-stop",
+            },
+            {
+              "angle": {
+                "unit": "deg",
+                "value": 180,
+              },
+              "rgba": {
+                "a": 1,
+                "b": 0,
+                "g": 255,
+                "r": 255,
+              },
+              "type": "angular-color-stop",
+            },
+            {
+              "angle": {
+                "unit": "deg",
+                "value": 270,
+              },
+              "rgba": {
+                "a": 1,
+                "b": 0,
+                "g": 128,
+                "r": 0,
+              },
+              "type": "angular-color-stop",
+            },
+            {
+              "angle": {
+                "unit": "deg",
+                "value": 360,
+              },
+              "rgba": {
+                "a": 1,
+                "b": 255,
+                "g": 0,
+                "r": 0,
+              },
+              "type": "angular-color-stop",
+            },
+          ],
+          "position": "center",
+          "type": "conic-gradient",
+        },
+      ]
+    `)
 })

--- a/src/lib/gradientParser.test.ts
+++ b/src/lib/gradientParser.test.ts
@@ -110,7 +110,12 @@ test("parseGradient(radial-gradient)", () => {
           ],
           "endingShape": "circle",
           "position": "top left",
-          "size": "farthest-corner",
+          "size": [
+            {
+              "unit": "em",
+              "value": 5,
+            },
+          ],
           "type": "radial-gradient",
         },
       ]

--- a/src/lib/gradientParser.test.ts
+++ b/src/lib/gradientParser.test.ts
@@ -31,8 +31,8 @@ test("parseGradient(linear-gradient)", () => {
             "type": "color-stop",
           },
         ],
-        "orientation": {
-          "type": "directional",
+        "gradientLine": {
+          "type": "side-or-corner",
           "value": "left",
         },
         "type": "linear-gradient",
@@ -73,8 +73,8 @@ test("parseGradient(linear-gradient)", () => {
             "type": "color-stop",
           },
         ],
-        "orientation": {
-          "type": "angular",
+        "gradientLine": {
+          "type": "angle",
           "value": 90,
         },
         "type": "linear-gradient",

--- a/src/lib/gradientParser.ts
+++ b/src/lib/gradientParser.ts
@@ -1,0 +1,223 @@
+import parse, { Node, FunctionNode, unit, Dimension, stringify } from "postcss-value-parser"
+import { colord, extend, RgbaColor } from "colord"
+import namesPlugin from "colord/plugins/names"
+
+extend([namesPlugin])
+
+export interface DirectionalNode {
+  type: "directional"
+  value:
+    | "left"
+    | "top"
+    | "bottom"
+    | "right"
+    | "left top"
+    | "top left"
+    | "left bottom"
+    | "bottom left"
+    | "right top"
+    | "top right"
+    | "right bottom"
+    | "bottom right"
+}
+
+export type GradientType =
+  | "linear-gradient"
+  | "repeating-linear-gradient"
+  | "radial-gradient"
+  | "repeating-radial-gradient"
+  | "conic-gradient"
+
+export type AngularNode = {
+  type: "angular"
+  // degrees
+  value: number
+}
+
+export type GradientNode = LinearGradient | RadialGradient
+
+export type Length = {
+  value: number
+  unit: string
+}
+
+export type ColorStop = {
+  type: "color-stop"
+  rgba: RgbaColor
+  position?: Length
+}
+
+export type ColorHint = {
+  type: "color-hint"
+  hint: Length
+}
+
+export type LinearGradient = {
+  type: "linear-gradient" | "repeating-linear-gradient"
+  orientation: DirectionalNode | AngularNode
+  colorStops: (ColorStop | ColorHint)[]
+}
+
+export type RadialGradient = {
+  type: "radial-gradient" | "repeating-radial-gradient"
+  endingShape: "circle" | "ellipse"
+  size: "closest-corner" | "closest-side" | "farthest-corner" | "farthest-side" | Length[]
+  position: string
+  colorStops: (ColorStop | ColorHint)[]
+}
+
+function splitSpaceArgs(nodes: Node[]): Node[] {
+  return nodes.filter((it) => it.type !== "space")
+}
+
+function splitCommaArgs(nodes: Node[]): Node[][] {
+  const ret: Node[][] = []
+  let i = 0
+  for (let j = 0; j < nodes.length; j++) {
+    if (nodes[j].type === "div") {
+      ret.push(splitSpaceArgs(nodes.slice(i, j)))
+      i = j + 1
+    }
+  }
+  ret.push(splitSpaceArgs(nodes.slice(i)))
+  return ret
+}
+
+export function parseGradient(css: string): GradientNode[] {
+  const parsed = parse(css)
+  const gradients = splitCommaArgs(parsed.nodes)
+  return gradients
+    .filter(
+      (nodes) =>
+        nodes.length === 1 && nodes[0].type === "function" && nodes[0].value.includes("-gradient")
+    )
+    .map(([node]) => {
+      const args = splitCommaArgs((node as FunctionNode).nodes)
+      const type = node.value.replace(/^-webkit-/, "")
+      if (type.includes("linear-gradient")) {
+        const ret: Partial<LinearGradient> = {
+          type: type as LinearGradient["type"]
+        }
+        if (args[0][0].value === "to") {
+          ret.orientation = {
+            type: "directional",
+            value: args
+              .shift()!
+              .slice(1)
+              .map((it) => it.value)
+              .join(" ") as DirectionalNode["value"]
+          }
+        } else {
+          const first = unit(args[0][0].value)
+          if (first && ["deg", "turn", "rad", "grad"].includes(first.unit)) {
+            ret.orientation = {
+              type: "angular",
+              value: toDegrees(first)
+            }
+            args.shift()
+          } else {
+            ret.orientation = {
+              type: "angular",
+              value: 180
+            }
+          }
+        }
+        ret.colorStops = args.map(toColorStopOrHint)
+        return ret as LinearGradient
+      } else if (type.includes("radial-gradient")) {
+        const ret: Partial<RadialGradient> = {
+          type: type as RadialGradient["type"],
+          endingShape: "ellipse",
+          size: "farthest-corner",
+          position: "center"
+        }
+        let hasShape = false
+        for (let i = 0; i < args[0].length; i++) {
+          const arg = args[0][i]
+          switch (arg.value) {
+            case "circle":
+            case "ellipse":
+              hasShape = true
+              ret.endingShape = arg.value
+              break
+            case "closest-corner":
+            case "closest-side":
+            case "farthest-corner":
+            case "farthest-side":
+              hasShape = true
+              ret.size = arg.value
+              break
+            case "at":
+              hasShape = true
+              ret.position = args[0]
+                .slice(i + 1)
+                .map((it) => stringify(it))
+                .join(" ")
+              break
+          }
+          // TODO dimension size
+        }
+        if (hasShape) args.shift()
+        ret.colorStops = args.map(toColorStopOrHint)
+        return ret as RadialGradient
+      }
+      // TODO conic-gradient()
+      throw new Error("Unsupported gradient: " + stringify(node))
+    })
+}
+
+function toDegrees({ number: str, unit }: Dimension): number {
+  const value = parseFloat(str)
+  switch (unit.toLowerCase()) {
+    case "deg":
+      return value
+    case "rad":
+      return (180 * value) / Math.PI
+    case "grad":
+      return (360 * value) / 400
+    case "turn":
+      return 360 * value
+  }
+  throw new Error("Unsupported dimension: " + unit)
+}
+
+function toRgba(node: Node): RgbaColor {
+  return colord(stringify(node)).toRgb()
+}
+
+function toColorStopOrHint(nodes: Node[]): ColorStop | ColorHint {
+  if (nodes.length === 2) {
+    const v = unit(nodes[1].value)
+    if (v) {
+      return {
+        type: "color-stop",
+        position: dimensionToLength(v),
+        rgba: toRgba(nodes[0])
+      }
+    }
+  }
+  if (nodes.length === 1) {
+    if (nodes[0].type === "word") {
+      const v = unit(nodes[0].value)
+      if (v) {
+        v.unit = v.unit.toLowerCase() || "px"
+        return {
+          type: "color-hint",
+          hint: dimensionToLength(v)
+        }
+      }
+    }
+    return {
+      type: "color-stop",
+      rgba: toRgba(nodes[0])
+    }
+  }
+  throw new Error("Invalid color stop: " + nodes.map((it) => stringify(it)).join(" "))
+}
+
+function dimensionToLength(v: Dimension): Length {
+  return {
+    unit: v.unit.toLowerCase() || "px",
+    value: parseFloat(v.number)
+  }
+}

--- a/src/lib/gradientParser.ts
+++ b/src/lib/gradientParser.ts
@@ -4,8 +4,8 @@ import namesPlugin from "colord/plugins/names"
 
 extend([namesPlugin])
 
-export interface DirectionalNode {
-  type: "directional"
+export interface SideOrCornerGradientLine {
+  type: "side-or-corner"
   value:
     | "left"
     | "top"
@@ -28,9 +28,9 @@ export type GradientType =
   | "repeating-radial-gradient"
   | "conic-gradient"
 
-export type AngularNode = {
-  type: "angular"
-  // degrees
+export type AngleGradientLine = {
+  type: "angle"
+  // Normalized to degrees
   value: number
 }
 
@@ -54,7 +54,7 @@ export type ColorHint = {
 
 export type LinearGradient = {
   type: "linear-gradient" | "repeating-linear-gradient"
-  orientation: DirectionalNode | AngularNode
+  gradientLine: SideOrCornerGradientLine | AngleGradientLine
   colorStops: (ColorStop | ColorHint)[]
 }
 
@@ -99,25 +99,25 @@ export function parseGradient(css: string): GradientNode[] {
           type: type as LinearGradient["type"]
         }
         if (args[0][0].value === "to") {
-          ret.orientation = {
-            type: "directional",
+          ret.gradientLine = {
+            type: "side-or-corner",
             value: args
               .shift()!
               .slice(1)
               .map((it) => it.value)
-              .join(" ") as DirectionalNode["value"]
+              .join(" ") as SideOrCornerGradientLine["value"]
           }
         } else {
           const first = unit(args[0][0].value)
           if (first && ["deg", "turn", "rad", "grad"].includes(first.unit)) {
-            ret.orientation = {
-              type: "angular",
+            ret.gradientLine = {
+              type: "angle",
               value: toDegrees(first)
             }
             args.shift()
           } else {
-            ret.orientation = {
-              type: "angular",
+            ret.gradientLine = {
+              type: "angle",
               value: 180
             }
           }

--- a/src/lib/gradientParser.ts
+++ b/src/lib/gradientParser.ts
@@ -41,6 +41,9 @@ export type Length = {
   unit: string
 }
 
+export type ColorStopList = ColorStopListItem[]
+export type ColorStopListItem = ColorStop | ColorHint | AngularColorStop
+
 export type ColorStop = {
   type: "color-stop"
   rgba: RgbaColor

--- a/src/shared/color.test.ts
+++ b/src/shared/color.test.ts
@@ -1,0 +1,41 @@
+import { assert, expect, test } from "vitest"
+import { cssToFigmaGradient } from "./color"
+
+test("cssToFigmaGradient(linear-gradient)", () => {
+  expect(cssToFigmaGradient("linear-gradient(to left, red, blue)")).toMatchInlineSnapshot(`
+    {
+      "gradientStops": [
+        {
+          "color": {
+            "a": 1,
+            "b": 0,
+            "g": 0,
+            "r": 1,
+          },
+          "position": 0,
+        },
+        {
+          "color": {
+            "a": 1,
+            "b": 1,
+            "g": 0,
+            "r": 0,
+          },
+          "position": 1,
+        },
+      ],
+      "gradientTransform": [
+        [
+          -1,
+          1.2246467991473532e-16,
+          0.9999999999999999,
+        ],
+        [
+          -1.2246467991473532e-16,
+          -1,
+          1,
+        ],
+      ],
+      "type": "GRADIENT_LINEAR",
+    }
+  `)})

--- a/src/shared/color.ts
+++ b/src/shared/color.ts
@@ -100,8 +100,8 @@ function calculateRotationAngle(parsedGradient: GradientNode): number {
     parsedGradient.type === "linear-gradient" ||
     parsedGradient.type === "repeating-linear-gradient"
   ) {
-    if (parsedGradient.orientation.type === "directional") {
-      switch (parsedGradient.orientation.value) {
+    if (parsedGradient.gradientLine.type === "side-or-corner") {
+      switch (parsedGradient.gradientLine.value) {
         case "left":
           additionalRotation = -90
           break
@@ -135,11 +135,11 @@ function calculateRotationAngle(parsedGradient: GradientNode): number {
       }
     } else {
       // css angle is clockwise from the y-axis, figma angles are counter-clockwise from the x-axis
-      additionalRotation = (convertCssAngle(parsedGradient.orientation.value) + 90) % 360
+      additionalRotation = (convertCssAngle(parsedGradient.gradientLine.value) + 90) % 360
       console.log(
         "parsed angle",
-        parsedGradient.orientation.value,
-        convertCssAngle(parsedGradient.orientation.value),
+        parsedGradient.gradientLine.value,
+        convertCssAngle(parsedGradient.gradientLine.value),
         additionalRotation
       )
       return degreesToRadians(additionalRotation)
@@ -170,8 +170,8 @@ function calculateLength(parsedGradient: GradientNode, width: number, height: nu
     parsedGradient.type === "linear-gradient" ||
     parsedGradient.type === "repeating-linear-gradient"
   ) {
-    if (parsedGradient.orientation.type === "directional") {
-      switch (parsedGradient.orientation.value) {
+    if (parsedGradient.gradientLine.type === "side-or-corner") {
+      switch (parsedGradient.gradientLine.value) {
         case "left":
         case "right":
           return width
@@ -190,12 +190,12 @@ function calculateLength(parsedGradient: GradientNode, width: number, height: nu
         default:
           throw "unsupported linear gradient orientation"
       }
-    } else if (parsedGradient.orientation.type === "angular") {
+    } else if (parsedGradient.gradientLine.type === "angle") {
       // from w3c: abs(W * sin(A)) + abs(H * cos(A))
       // https://w3c.github.io/csswg-drafts/css-images-3/#linear-gradients
-      const rads = degreesToRadians(convertCssAngle(parsedGradient.orientation.value))
+      const rads = degreesToRadians(convertCssAngle(parsedGradient.gradientLine.value))
       return Math.abs(width * Math.sin(rads)) + Math.abs(height * Math.cos(rads))
-    } else if (!parsedGradient.orientation) {
+    } else if (!parsedGradient.gradientLine) {
       return height // default to bottom
     }
   } else if (parsedGradient.type === "radial-gradient") {
@@ -211,8 +211,8 @@ function calculateScale(parsedGradient: GradientNode): [number, number] {
     parsedGradient.type === "linear-gradient" ||
     parsedGradient.type === "repeating-linear-gradient"
   ) {
-    if (parsedGradient.orientation.type === "directional") {
-      switch (parsedGradient.orientation.value) {
+    if (parsedGradient.gradientLine.type === "side-or-corner") {
+      switch (parsedGradient.gradientLine.value) {
         case "left":
         case "right":
         case "bottom":
@@ -231,13 +231,13 @@ function calculateScale(parsedGradient: GradientNode): [number, number] {
         default:
           throw "unsupported linear gradient orientation"
       }
-    } else if (parsedGradient.orientation.type === "angular") {
+    } else if (parsedGradient.gradientLine.type === "angle") {
       // from w3c: abs(W * sin(A)) + abs(H * cos(A))
       // https://w3c.github.io/csswg-drafts/css-images-3/#linear-gradients
       // W and H are unit vectors, so we can just use 1
       const scale =
-        Math.abs(Math.sin(degreesToRadians(convertCssAngle(parsedGradient.orientation.value)))) +
-        Math.abs(Math.cos(degreesToRadians(convertCssAngle(parsedGradient.orientation.value))))
+        Math.abs(Math.sin(degreesToRadians(convertCssAngle(parsedGradient.gradientLine.value)))) +
+        Math.abs(Math.cos(degreesToRadians(convertCssAngle(parsedGradient.gradientLine.value))))
 
       return [1.0 / scale, 1.0 / scale]
     }
@@ -256,8 +256,8 @@ function calculateTranslationToCenter(parsedGradient: GradientNode): [number, nu
     parsedGradient.type === "linear-gradient" ||
     parsedGradient.type === "repeating-linear-gradient"
   ) {
-    if (parsedGradient.orientation.type === "directional") {
-      switch (parsedGradient.orientation.value) {
+    if (parsedGradient.gradientLine.type === "side-or-corner") {
+      switch (parsedGradient.gradientLine.value) {
         case "left":
           return [-1, -0.5]
         case "right":
@@ -281,8 +281,8 @@ function calculateTranslationToCenter(parsedGradient: GradientNode): [number, nu
         default:
           throw "unsupported linear gradient orientation"
       }
-    } else if (parsedGradient.orientation.type === "angular") {
-      const angle = convertCssAngle(parsedGradient.orientation.value)
+    } else if (parsedGradient.gradientLine.type === "angle") {
+      const angle = convertCssAngle(parsedGradient.gradientLine.value)
       if (angle === 0) {
         return [-0.5, -1]
       } else if (angle === 90) {
@@ -300,7 +300,7 @@ function calculateTranslationToCenter(parsedGradient: GradientNode): [number, nu
       } else if (angle > 270 && angle < 360) {
         return [0, -1]
       }
-    } else if (parsedGradient.type === "linear-gradient" && !parsedGradient.orientation) {
+    } else if (parsedGradient.type === "linear-gradient" && !parsedGradient.gradientLine) {
       return [-0.5, 0] // default to bottom
     }
   } else if (parsedGradient.type === "radial-gradient") {

--- a/src/shared/color.ts
+++ b/src/shared/color.ts
@@ -1,5 +1,5 @@
 import { rotate, translate, compose, scale } from "transformation-matrix"
-import { GradientNode, parseGradient, ColorStop } from "../lib/gradientParser"
+import { GradientNode, parseGradient, ColorStop, ColorStopList } from "../lib/gradientParser"
 import type { RgbaColor } from "colord"
 
 function rgbaToFigmaRgba({ r, g, b, a }: RgbaColor): RGBA {
@@ -21,7 +21,9 @@ export function cssToFigmaGradient(css: string, width = 1, height = 1): Gradient
     rotate(rotationAngle),
     translate(tx, ty)
   )
-  let colorStops = parsedGradient.colorStops.filter((it) => it.type === "color-stop") as ColorStop[]
+  let colorStops = (parsedGradient.colorStops as ColorStopList).filter(
+    (it: any) => it.type === "color-stop"
+  ) as ColorStop[]
   console.log("color stops", colorStops)
 
   let previousPosition: number | undefined = undefined
@@ -32,7 +34,7 @@ export function cssToFigmaGradient(css: string, width = 1, height = 1): Gradient
       previousPosition = position
       return {
         position,
-      color: rgbaToFigmaRgba(stop.rgba)
+        color: rgbaToFigmaRgba(stop.rgba)
       }
     }),
     gradientTransform: [

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,8 +1,8 @@
 import { Container, Textbox, Text, Button } from "@create-figma-plugin/ui"
-import { parse as parseGradient } from "gradient-parser"
 import { emit } from "@create-figma-plugin/utilities"
 import { h, JSX } from "preact"
 import { useState } from "preact/hooks"
+import { parseGradient } from "../lib/gradientParser"
 import { ReqInsertCSSHandler } from "../shared/types"
 
 export function App() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@create-figma-plugin/tsconfig",
   "compilerOptions": {
+    "skipLibCheck": true,
     "typeRoots": ["node_modules/@figma", "node_modules/@types"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,10 +1974,10 @@ typed-function@^4.1.0:
   resolved "https://registry.yarnpkg.com/typed-function/-/typed-function-4.1.0.tgz#da4bdd8a6d19a89e22732f75e4a410860aaf9712"
   integrity sha512-DGwUl6cioBW5gw2L+6SMupGwH/kZOqivy17E4nsh1JI9fKF87orMmlQx3KISQPmg3sfnOUGlwVkroosvgddrlg==
 
-typescript@^4:
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
-  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
+typescript@^4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 unique-string@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,10 +62,20 @@
     natural-compare-lite "1.4.0"
     rgb-hex "^4.0.0"
 
+"@esbuild/android-arm@0.15.11":
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.15.11.tgz#bdd9c3e098183bdca97075aa4c3e0152ed3e10ee"
+  integrity sha512-PzMcQLazLBkwDEkrNPi9AbjFt6+3I7HKbiYF2XtWQ7wItrHvEOeO3T8Am434zAozWtVP7lrTue1bEfc2nYWeCA==
+
 "@esbuild/android-arm@0.15.9":
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.15.9.tgz#7e1221604ab88ed5021ead74fa8cca4405e1e431"
   integrity sha512-VZPy/ETF3fBG5PiinIkA0W/tlsvlEgJccyN2DzWZEl0DlVKRbu91PvY2D6Lxgluj4w9QtYHjOWjAT44C+oQ+EQ==
+
+"@esbuild/linux-loong64@0.15.11":
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.11.tgz#2f4f9a1083dcb4fc65233b6f59003c406abf32e5"
+  integrity sha512-geWp637tUhNmhL3Xgy4Bj703yXB9dqiLJe05lCUfjSFDrQf9C/8pArusyPUbUbPwlC/EAUjBw32sxuIl/11dZw==
 
 "@esbuild/linux-loong64@0.15.9":
   version "0.15.9"
@@ -119,6 +129,18 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
+"@types/chai-subset@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai-subset/-/chai-subset-1.3.3.tgz#97893814e92abd2c534de422cb377e0e0bdaac94"
+  integrity sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*", "@types/chai@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.3.tgz#3c90752792660c4b562ad73b3fbd68bf3bc7ae07"
+  integrity sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==
+
 "@types/css-modules-loader-core@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/css-modules-loader-core/-/css-modules-loader-core-1.1.0.tgz#67af15aa16603ac2ffc1d3a7f08547ac809c3005"
@@ -126,10 +148,15 @@
   dependencies:
     postcss "7.x.x"
 
-"@types/gradient-parser@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@types/gradient-parser/-/gradient-parser-0.1.2.tgz#15eb545e4b6ae0f7f6e609b7d32937c7138dfa4c"
-  integrity sha512-e2s1svCYJY8JDr2t/OoB/H4aWZy4sXUOAZ0NdSSHjKACw1jeU54gf4xj38di0AgVIObgzN1JSikJ5oSo3vxwgA==
+"@types/node@*":
+  version "18.11.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.0.tgz#f38c7139247a1d619f6cc6f27b072606af7c289d"
+  integrity sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==
+
+acorn@^8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -167,6 +194,11 @@ anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -238,6 +270,19 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001400:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz#30f67d55a865da43e0aeec003f073ea8764d5d7c"
   integrity sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==
 
+chai@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.6.tgz#ffe4ba2d9fa9d6680cc0b370adae709ec9011e9c"
+  integrity sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    loupe "^2.3.1"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
 chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -265,6 +310,11 @@ chalk@^4.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
 chokidar@^3.4.0, chokidar@^3.5.3:
   version "3.5.3"
@@ -314,7 +364,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colord@^2.9.1:
+colord@^2.9.1, colord@^2.9.3:
   version "2.9.3"
   resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.3.tgz#4f8ce919de456f1d5c1c368c307fe20f3e59fb43"
   integrity sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==
@@ -451,6 +501,13 @@ csso@^4.2.0:
   dependencies:
     css-tree "^1.1.2"
 
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -460,6 +517,13 @@ decimal.js@^10.4.0:
   version "10.4.1"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.1.tgz#be75eeac4a2281aace80c1a8753587c27ef053e7"
   integrity sha512-F29o+vci4DodHYT9UrR5IEbfBw9pE5eSapIJdTqXK5+6hq+t8VRxwQyKlW2i+KDKFkkJQRvFyI/QXD83h8LyQw==
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -513,100 +577,200 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
+esbuild-android-64@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.15.11.tgz#50402129c3e85bb06434e212374c5f693e4c5f01"
+  integrity sha512-rrwoXEiuI1kaw4k475NJpexs8GfJqQUKcD08VR8sKHmuW9RUuTR2VxcupVvHdiGh9ihxL9m3lpqB1kju92Ialw==
+
 esbuild-android-64@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.15.9.tgz#4a7eb320ca8d3a305f14792061fd9614ccebb7c0"
   integrity sha512-HQCX7FJn9T4kxZQkhPjNZC7tBWZqJvhlLHPU2SFzrQB/7nDXjmTIFpFTjt7Bd1uFpeXmuwf5h5fZm+x/hLnhbw==
+
+esbuild-android-arm64@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.15.11.tgz#49bee35218ea2ccf1a0c5f187af77c1c0a5dee71"
+  integrity sha512-/hDubOg7BHOhUUsT8KUIU7GfZm5bihqssvqK5PfO4apag7YuObZRZSzViyEKcFn2tPeHx7RKbSBXvAopSHDZJQ==
 
 esbuild-android-arm64@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.15.9.tgz#c948e5686df20857ad361ec67e070d40d7cab985"
   integrity sha512-E6zbLfqbFVCNEKircSHnPiSTsm3fCRxeIMPfrkS33tFjIAoXtwegQfVZqMGR0FlsvVxp2NEDOUz+WW48COCjSg==
 
+esbuild-darwin-64@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.15.11.tgz#89a90c8cf6f0029ac4169bfedd012a0412c1575f"
+  integrity sha512-1DqHD0ms3AhiwkKnjRUzmiW7JnaJJr5FKrPiR7xuyMwnjDqvNWDdMq4rKSD9OC0piFNK6n0LghsglNMe2MwJtA==
+
 esbuild-darwin-64@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.15.9.tgz#25f564fa4b39c1cec84dc46bce5634fdbce1d5e4"
   integrity sha512-gI7dClcDN/HHVacZhTmGjl0/TWZcGuKJ0I7/xDGJwRQQn7aafZGtvagOFNmuOq+OBFPhlPv1T6JElOXb0unkSQ==
+
+esbuild-darwin-arm64@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.11.tgz#556f4385c6de806cc81132dd7b8af00fe9d292df"
+  integrity sha512-OMzhxSbS0lwwrW40HHjRCeVIJTURdXFA8c3GU30MlHKuPCcvWNUIKVucVBtNpJySXmbkQMDJdJNrXzNDyvoqvQ==
 
 esbuild-darwin-arm64@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.9.tgz#60faea3ed95d15239536aa88d06bb82b29278a86"
   integrity sha512-VZIMlcRN29yg/sv7DsDwN+OeufCcoTNaTl3Vnav7dL/nvsApD7uvhVRbgyMzv0zU/PP0xRhhIpTyc7lxEzHGSw==
 
+esbuild-freebsd-64@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.11.tgz#fd86fd1b3b65366048f35b996d9cdf3547384eee"
+  integrity sha512-8dKP26r0/Qyez8nTCwpq60QbuYKOeBygdgOAWGCRalunyeqWRoSZj9TQjPDnTTI9joxd3QYw3UhVZTKxO9QdRg==
+
 esbuild-freebsd-64@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.9.tgz#0339ef1c90a919175e7816788224517896657a0e"
   integrity sha512-uM4z5bTvuAXqPxrI204txhlsPIolQPWRMLenvGuCPZTnnGlCMF2QLs0Plcm26gcskhxewYo9LkkmYSS5Czrb5A==
+
+esbuild-freebsd-arm64@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.11.tgz#d346bcacfe9779ebc1a11edac1bdedeff6dda3b1"
+  integrity sha512-aSGiODiukLGGnSg/O9+cGO2QxEacrdCtCawehkWYTt5VX1ni2b9KoxpHCT9h9Y6wGqNHmXFnB47RRJ8BIqZgmQ==
 
 esbuild-freebsd-arm64@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.9.tgz#32abfc0be3ae3dd38e5a86a9beadbbcf592f1b57"
   integrity sha512-HHDjT3O5gWzicGdgJ5yokZVN9K9KG05SnERwl9nBYZaCjcCgj/sX8Ps1jvoFSfNCO04JSsHSOWo4qvxFuj8FoA==
 
+esbuild-linux-32@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.15.11.tgz#64b50e774bf75af7dcc6a73ad509f2eb0ac4487b"
+  integrity sha512-lsrAfdyJBGx+6aHIQmgqUonEzKYeBnyfJPkT6N2dOf1RoXYYV1BkWB6G02tjsrz1d5wZzaTc3cF+TKmuTo/ZwA==
+
 esbuild-linux-32@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.15.9.tgz#93581348a4da7ed2b29bc5539f2605ad7fcee77b"
   integrity sha512-AQIdE8FugGt1DkcekKi5ycI46QZpGJ/wqcMr7w6YUmOmp2ohQ8eO4sKUsOxNOvYL7hGEVwkndSyszR6HpVHLFg==
+
+esbuild-linux-64@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.15.11.tgz#fba3a78b95769772863f8f6dc316abca55cf8416"
+  integrity sha512-Y2Rh+PcyVhQqXKBTacPCltINN3uIw2xC+dsvLANJ1SpK5NJUtxv8+rqWpjmBgaNWKQT1/uGpMmA9olALy9PLVA==
 
 esbuild-linux-64@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.15.9.tgz#0d171e7946c95d0d3ed4826026af2c5632d7dcc4"
   integrity sha512-4RXjae7g6Qs7StZyiYyXTZXBlfODhb1aBVAjd+ANuPmMhWthQilWo7rFHwJwL7DQu1Fjej2sODAVwLbcIVsAYQ==
 
+esbuild-linux-arm64@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.11.tgz#c0cb31980eee066bfd39a4593660a0ecebe926cb"
+  integrity sha512-uhcXiTwTmD4OpxJu3xC5TzAAw6Wzf9O1XGWL448EE9bqGjgV1j+oK3lIHAfsHnuIn8K4nDW8yjX0Sv5S++oRuw==
+
 esbuild-linux-arm64@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.9.tgz#9838795a3720cbe736d3bc20621bd366eac22f24"
   integrity sha512-a+bTtxJmYmk9d+s2W4/R1SYKDDAldOKmWjWP0BnrWtDbvUBNOm++du0ysPju4mZVoEFgS1yLNW+VXnG/4FNwdQ==
+
+esbuild-linux-arm@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.15.11.tgz#7824d20099977aa671016c7de7a5038c9870010f"
+  integrity sha512-TJllTVk5aSyqPFvvcHTvf6Wu1ZKhWpJ/qNmZO8LL/XeB+LXCclm7HQHNEIz6MT7IX8PmlC1BZYrOiw2sXSB95A==
 
 esbuild-linux-arm@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.15.9.tgz#dce96cd817bc7376f6af3967649c4ab1f2f79506"
   integrity sha512-3Zf2GVGUOI7XwChH3qrnTOSqfV1V4CAc/7zLVm4lO6JT6wbJrTgEYCCiNSzziSju+J9Jhf9YGWk/26quWPC6yQ==
 
+esbuild-linux-mips64le@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.11.tgz#10627331c90164e553429ed25e025184bba485b6"
+  integrity sha512-WD61y/R1M4BLe4gxXRypoQ0Ci+Vjf714QYzcPNkiYv5I8K8WDz2ZR8Bm6cqKxd6rD+e/rZgPDbhQ9PCf7TMHmA==
+
 esbuild-linux-mips64le@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.9.tgz#0335a0739e61aa97cb9b4a018e3facfcca9cdcfd"
   integrity sha512-Zn9HSylDp89y+TRREMDoGrc3Z4Hs5u56ozZLQCiZAUx2+HdbbXbWdjmw3FdTJ/i7t5Cew6/Q+6kfO3KCcFGlyw==
+
+esbuild-linux-ppc64le@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.11.tgz#be42679a36a5246b893fc8b898135ebacb5a0a14"
+  integrity sha512-JVleZS9oPVLTlBhPTWgOwxFWU/wMUdlBwTbGA4GF8c38sLbS13cupj+C8bLq929jU7EMWry4SaL+tKGIaTlqKg==
 
 esbuild-linux-ppc64le@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.9.tgz#18482afb95b8a705e2da0a59d7131bff221281f9"
   integrity sha512-OEiOxNAMH9ENFYqRsWUj3CWyN3V8P3ZXyfNAtX5rlCEC/ERXrCEFCJji/1F6POzsXAzxvUJrTSTCy7G6BhA6Fw==
 
+esbuild-linux-riscv64@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.11.tgz#3ac2f328e3db73cbff833ada94314d8e79503e54"
+  integrity sha512-9aLIalZ2HFHIOZpmVU11sEAS9F8TnHw49daEjcgMpBXHFF57VuT9f9/9LKJhw781Gda0P9jDkuCWJ0tFbErvJw==
+
 esbuild-linux-riscv64@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.9.tgz#03b6f9708272c117006b9ce1c9ae8aab91b5a5b6"
   integrity sha512-ukm4KsC3QRausEFjzTsOZ/qqazw0YvJsKmfoZZm9QW27OHjk2XKSQGGvx8gIEswft/Sadp03/VZvAaqv5AIwNA==
+
+esbuild-linux-s390x@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.11.tgz#e774e0df061b6847d86783bf3c8c4300a72e03ad"
+  integrity sha512-sZHtiXXOKsLI3XGBGoYO4qKBzJlb8xNsWmvFiwFMHFzA4AXgDP1KDp7Dawe9C2pavTRBDvl+Ok4n/DHQ59oaTg==
 
 esbuild-linux-s390x@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.9.tgz#65fb645623d575780f155f0ee52935e62f9cca4f"
   integrity sha512-uDOQEH55wQ6ahcIKzQr3VyjGc6Po/xblLGLoUk3fVL1qjlZAibtQr6XRfy5wPJLu/M2o0vQKLq4lyJ2r1tWKcw==
 
+esbuild-netbsd-64@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.11.tgz#55e265fa4489e3f396b16c81f6f5a11d6ca2a9a4"
+  integrity sha512-hUC9yN06K9sg7ju4Vgu9ChAPdsEgtcrcLfyNT5IKwKyfpLvKUwCMZSdF+gRD3WpyZelgTQfJ+pDx5XFbXTlB0A==
+
 esbuild-netbsd-64@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.9.tgz#7894297bb9e11f3d2f6f31efecd1be4e181f0d54"
   integrity sha512-yWgxaYTQz+TqX80wXRq6xAtb7GSBAp6gqLKfOdANg9qEmAI1Bxn04IrQr0Mzm4AhxvGKoHzjHjMgXbCCSSDxcw==
+
+esbuild-openbsd-64@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.11.tgz#bc04103ccfd8c2f2241e1add0b51a095955b73c4"
+  integrity sha512-0bBo9SQR4t66Wd91LGMAqmWorzO0TTzVjYiifwoFtel8luFeXuPThQnEm5ztN4g0fnvcp7AnUPPzS/Depf17wQ==
 
 esbuild-openbsd-64@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.9.tgz#0f9d4c6b6772ae50d491d68ad4cc028300dda7c0"
   integrity sha512-JmS18acQl4iSAjrEha1MfEmUMN4FcnnrtTaJ7Qg0tDCOcgpPPQRLGsZqhes0vmx8VA6IqRyScqXvaL7+Q0Uf3A==
 
+esbuild-sunos-64@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.15.11.tgz#ccd580305d31fde07b5c386da79c942aaf069013"
+  integrity sha512-EuBdTGlsMTjEl1sQnBX2jfygy7iR6CKfvOzi+gEOfhDqbHXsmY1dcpbVtcwHAg9/2yUZSfMJHMAgf1z8M4yyyw==
+
 esbuild-sunos-64@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.15.9.tgz#c32b7ce574b08f814de810ce7c1e34b843768126"
   integrity sha512-UKynGSWpzkPmXW3D2UMOD9BZPIuRaSqphxSCwScfEE05Be3KAmvjsBhht1fLzKpiFVJb0BYMd4jEbWMyJ/z1hQ==
+
+esbuild-windows-32@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.15.11.tgz#40fe1d48f9b20a76f6db5109aaaf1511aed58c71"
+  integrity sha512-O0/Wo1Wk6dc0rZSxkvGpmTNIycEznHmkObTFz2VHBhjPsO4ZpCgfGxNkCpz4AdAIeMczpTXt/8d5vdJNKEGC+Q==
 
 esbuild-windows-32@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.15.9.tgz#37a8f7cfccdb2177cd46613a1a1e1fcb419d36df"
   integrity sha512-aqXvu4/W9XyTVqO/hw3rNxKE1TcZiEYHPsXM9LwYmKSX9/hjvfIJzXwQBlPcJ/QOxedfoMVH0YnhhQ9Ffb0RGA==
 
+esbuild-windows-64@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.15.11.tgz#80c58b1ef2ff030c78e3a06e7a922776cc4cb687"
+  integrity sha512-x977Q4HhNjnHx00b4XLAnTtj5vfbdEvkxaQwC1Zh5AN8g5EX+izgZ6e5QgqJgpzyRNJqh4hkgIJF1pyy1be0mQ==
+
 esbuild-windows-64@0.15.9:
   version "0.15.9"
   resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.15.9.tgz#5fe1e76fc13dd7f520febecaea110b6f1649c7b2"
   integrity sha512-zm7h91WUmlS4idMtjvCrEeNhlH7+TNOmqw5dJPJZrgFaxoFyqYG6CKDpdFCQXdyKpD5yvzaQBOMVTCBVKGZDEg==
+
+esbuild-windows-arm64@0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.11.tgz#018624023b5c3f0cca334cc99f5ef7134d396333"
+  integrity sha512-VwUHFACuBahrvntdcMKZteUZ9HaYrBRODoKe4tIWxguQRvvYoYb7iu5LrcRS/FQx8KPZNaa72zuqwVtHeXsITw==
 
 esbuild-windows-arm64@0.15.9:
   version "0.15.9"
@@ -640,6 +804,34 @@ esbuild@^0.15.5:
     esbuild-windows-32 "0.15.9"
     esbuild-windows-64 "0.15.9"
     esbuild-windows-arm64 "0.15.9"
+
+esbuild@^0.15.9:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.15.11.tgz#524d48612a9aa7edc1753c83459cb6fcae0cb66e"
+  integrity sha512-OgHGuhlfZ//mToxjte1D5iiiQgWfJ2GByVMwEC/IuoXsBGkuyK1+KrjYu0laSpnN/L1UmLUCv0s25vObdc1bVg==
+  optionalDependencies:
+    "@esbuild/android-arm" "0.15.11"
+    "@esbuild/linux-loong64" "0.15.11"
+    esbuild-android-64 "0.15.11"
+    esbuild-android-arm64 "0.15.11"
+    esbuild-darwin-64 "0.15.11"
+    esbuild-darwin-arm64 "0.15.11"
+    esbuild-freebsd-64 "0.15.11"
+    esbuild-freebsd-arm64 "0.15.11"
+    esbuild-linux-32 "0.15.11"
+    esbuild-linux-64 "0.15.11"
+    esbuild-linux-arm "0.15.11"
+    esbuild-linux-arm64 "0.15.11"
+    esbuild-linux-mips64le "0.15.11"
+    esbuild-linux-ppc64le "0.15.11"
+    esbuild-linux-riscv64 "0.15.11"
+    esbuild-linux-s390x "0.15.11"
+    esbuild-netbsd-64 "0.15.11"
+    esbuild-openbsd-64 "0.15.11"
+    esbuild-sunos-64 "0.15.11"
+    esbuild-windows-32 "0.15.11"
+    esbuild-windows-64 "0.15.11"
+    esbuild-windows-arm64 "0.15.11"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -731,6 +923,11 @@ fsevents@~2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
 generic-names@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/generic-names/-/generic-names-4.0.0.tgz#0bd8a2fd23fe8ea16cbd0a279acd69c06933d9a3"
@@ -742,6 +939,11 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
@@ -778,11 +980,6 @@ graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-gradient-parser@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/gradient-parser/-/gradient-parser-1.0.2.tgz#d283b80390386e2613c992bb0e5abb259aedf25f"
-  integrity sha512-gR6nY33xC9yJoH4wGLQtZQMXDi6RI3H37ERu7kQCVUzlXjNedpZM7xcA489Opwbq0BSGohtWGsWsntupmxelMg==
-
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -804,6 +1001,13 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 hex-rgb@^5.0.0:
   version "5.0.0"
@@ -857,6 +1061,13 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-core-module@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
+  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
+  dependencies:
+    has "^1.0.3"
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -924,6 +1135,11 @@ loader-utils@^3.2.0:
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-3.2.0.tgz#bcecc51a7898bee7473d4bc6b845b23af8304d4f"
   integrity sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==
 
+local-pkg@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.2.tgz#13107310b77e74a0e513147a131a2ba288176c2f"
+  integrity sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -957,6 +1173,13 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
+
+loupe@^2.3.1:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.4.tgz#7e0b9bffc76f148f9be769cb1321d3dcf3cb25f3"
+  integrity sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==
+  dependencies:
+    get-func-name "^2.0.0"
 
 mathjs@^11.2.1:
   version "11.2.1"
@@ -1007,6 +1230,11 @@ mri@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
   integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 nanoid@^3.3.4:
   version "3.3.4"
@@ -1102,10 +1330,20 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
 picocolors@^0.2.1:
   version "0.2.1"
@@ -1477,6 +1715,15 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
+resolve@^1.22.1:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -1491,6 +1738,13 @@ rgb-hex@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/rgb-hex/-/rgb-hex-4.0.0.tgz#02fb1e215e3fe5d070501579a3d2e4fa3c0acec8"
   integrity sha512-Eg2ev5CiMBnQ9Gpflmqbwbso0CCdISqtVIow7OpYSLN1ULUv2jTB9YieS1DSSn/17AD7KkPWDPzSFzI4GSuu/Q==
+
+rollup@~2.78.0:
+  version "2.78.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.78.1.tgz#52fe3934d9c83cb4f7c4cb5fb75d88591be8648f"
+  integrity sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 run-parallel@^1.1.9:
   version "1.2.0"
@@ -1569,6 +1823,13 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
+strip-literal@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-0.4.2.tgz#4f9fa6c38bb157b924e9ace7155ebf8a2342cbcf"
+  integrity sha512-pv48ybn4iE1O9RLgCAN0iU4Xv7RlBTiit6DKmMiErbs9x1wH6vXBs45tWc0H5wUIF6TLTrKweqkmYF/iraQKNw==
+  dependencies:
+    acorn "^8.8.0"
+
 stylehacks@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-5.1.0.tgz#a40066490ca0caca04e96c6b02153ddc39913520"
@@ -1602,6 +1863,11 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 svgo@^2.7.0:
   version "2.8.0"
@@ -1646,6 +1912,21 @@ tiny-emitter@^2.1.0:
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
+tinybench@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.3.1.tgz#14f64e6b77d7ef0b1f6ab850c7a808c6760b414d"
+  integrity sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==
+
+tinypool@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.3.0.tgz#c405d8b743509fc28ea4ca358433190be654f819"
+  integrity sha512-NX5KeqHOBZU6Bc0xj9Vr5Szbb1j8tUHIeD18s41aDJaPeC5QTdEhK0SpdpUrZlj2nv5cctNcSjaKNanXlfcVEQ==
+
+tinyspy@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-1.0.2.tgz#6da0b3918bfd56170fb3cd3a2b5ef832ee1dff0d"
+  integrity sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
@@ -1657,6 +1938,11 @@ transformation-matrix@^2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/transformation-matrix/-/transformation-matrix-2.13.0.tgz#4b367e715049197be8b658ac0fe6aed51fb43088"
   integrity sha512-TAkpbTWNBG/tlI68WEFHUQlK71PBIk+7EBqE91qi7NNho3EO5APqDw19FY7Clkeom5GhyAcGQPqn0wsD8WkYfA==
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^1.0.1:
   version "1.4.0"
@@ -1722,6 +2008,35 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+vite@^3.0.0:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-3.1.8.tgz#fa29144167d19b773baffd65b3972ea4c12359c9"
+  integrity sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==
+  dependencies:
+    esbuild "^0.15.9"
+    postcss "^8.4.16"
+    resolve "^1.22.1"
+    rollup "~2.78.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+vitest@^0.24.3:
+  version "0.24.3"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.24.3.tgz#d91c7e2d557877d5270033efdf18add6063f0c97"
+  integrity sha512-aM0auuPPgMSstWvr851hB74g/LKaKBzSxcG3da7ejfZbx08Y21JpZmbmDYrMTCGhVZKqTGwzcnLMwyfz2WzkhQ==
+  dependencies:
+    "@types/chai" "^4.3.3"
+    "@types/chai-subset" "^1.3.3"
+    "@types/node" "*"
+    chai "^4.3.6"
+    debug "^4.3.4"
+    local-pkg "^0.4.2"
+    strip-literal "^0.4.2"
+    tinybench "^2.3.0"
+    tinypool "^0.3.0"
+    tinyspy "^1.0.2"
+    vite "^3.0.0"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- add unit tests with vitest -> requires tsconfig skipLibCheck as per:
https://github.com/figma/plugin-typings/issues/96

- also use colord (with names plugin) for color normalization
- now supports all color types (including names and transparency)
- now supports diagonal directions
- now supports length w/o unit (px is implicit)

TODO:
- [x] support radial-gradient numeric size

Future:
- support conic-gradient ? (mappable to figma ?)
- support color hints ? (will have to interpolate the middle color)